### PR TITLE
Update Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,21 +16,15 @@ If you need the latest versions of wine on legacy versions of macOS use [macport
 <br>
 
 ### How to install using brew;
-First add `cask-versions`
-```
-brew tap homebrew/cask-versions
-```
-
-<br>
 
 ##### Available packages;
 - `wine-stable`
-- `wine-devel`
-- `wine-staging`
+- `wine@devel`
+- `wine@staging`
 
 <br>
 
-##### Next select the desired wine package to be installed, for an example I'll select `wine-stable`
+##### Select the desired wine package to be installed, for an example I'll select `wine-stable`
 ```
 brew install --cask --no-quarantine wine-stable
 ```


### PR DESCRIPTION
[`cask-versions`](https://github.com/Homebrew/homebrew-cask-versions) is now deprecated and alternative Wine casks has been migrated to the main `cask` tap.